### PR TITLE
New component: watch

### DIFF
--- a/src/G431/main.c
+++ b/src/G431/main.c
@@ -4,6 +4,7 @@
 #include "printing.h"
 #include <assert.h>
 #include "tmp_gpio.h"
+#include "watch.h"
 
 void __assert_func (const char * file, int line, const char * funct, const char *expr)
 {
@@ -32,6 +33,7 @@ extern bl_comp_def_t bl_mux2_def;
 extern bl_comp_def_t bl_sum2_def;
 extern bl_comp_def_t bl_perftimer_def;
 extern bl_comp_def_t bl_gpio_def;
+extern bl_comp_def_t bl_watch_def;
 
 gpio_port_config_t const portA = { GPIOA, {
     { BGPIO_MD_ANA,  BGPIO_OUT_PP, BGPIO_SPD_SLOW, BGPIO_PULL_NONE, BGPIO_AF0 }, // PA0  = VBUS
@@ -91,10 +93,19 @@ gpio_port_config_t const portC = { GPIOC, {
 }};
 
 
+watch_pin_config_t watch_pers[] = {
+    { BL_TYPE_BIT, "in", "in: %1b " },
+    { BL_TYPE_BIT, "oe", "oe: %1b " },
+    { BL_TYPE_BIT, "out", "out: %1b " },
+    { BL_TYPE_FLOAT, "output", "output: %6.3f\n" },
+    { BL_TYPE_BIT, NULL, NULL }
+};
+
 bl_inst_def_t const instances[] = {
     { "PortA", &bl_gpio_def, &portA},
     { "PortB", &bl_gpio_def, &portB},
     { "PortC", &bl_gpio_def, &portC},
+    { "watcher", &bl_watch_def, &watch_pers},
     { "ramp_sum", &bl_sum2_def, NULL },
     { "inv_sum", &bl_sum2_def, NULL },
     { "timer", &bl_perftimer_def, NULL },
@@ -110,12 +121,12 @@ char const * const nets[] = {
     "BIT", "ramp", "ramp_mux", "sel",
     "FLOAT", "slope", "dir_mux", "out", "ramp_sum", "in1",
     "FLOAT", "ramp_gain", "ramp_mux", "out", "ramp_sum", "gain1",
-    "FLOAT", "output", "ramp_sum", "out", "ramp_sum", "in0",
+    "FLOAT", "output", "ramp_sum", "out", "ramp_sum", "in0", "watcher", "output",
     "U32", "clocks", "timer", "time",
     "BIT", "LED", "PortC", "10_in", "PortC", "06_out",
-    "BIT", "oe", "PortB", "08_oe",
-    "BIT", "out", "PortB", "08_out",
-    "BIT", "in", "PortB", "08_in",
+    "BIT", "oe", "PortB", "08_oe", "watcher", "oe",
+    "BIT", "out", "PortB", "08_out", "watcher", "out",
+    "BIT", "in", "PortB", "08_in", "watcher", "in",
     NULL
 };
 
@@ -144,6 +155,8 @@ char const * const threads[] = {
     "PortB", "write",
     "PortC", "write",
     "timer", "stop",
+    "HAS_FP", "1000000000", "watch_thread",
+    "watcher", "update",
     NULL
 };
 
@@ -152,7 +165,8 @@ char const * const threads[] = {
 int main (void) {
     char *hello = "\nHello, world!\n";
     uint32_t t_start, t_inst, t_nets, t_setsig, t_setpin, t_threads, t_total;
-    bl_thread_data_t *thread;
+    bl_thread_data_t *main_thread;
+    bl_thread_data_t *watch_thread;
     char c;
     bl_sig_data_t data;
 
@@ -195,8 +209,10 @@ int main (void) {
     bl_show_all_threads();
 
     
-    thread = bl_find_thread_data_by_name("main_thread");
-    assert(thread != NULL);
+    main_thread = bl_find_thread_data_by_name("main_thread");
+    watch_thread = bl_find_thread_data_by_name("watch_thread");
+    assert(main_thread != NULL);
+    assert(watch_thread != NULL);
     while (1) {
         print_string("ready... ");
         // wait for key pressed
@@ -241,11 +257,12 @@ int main (void) {
         }
         print_string("running...");
         t_start = tsc_read();
-        bl_thread_update(thread, 1);
+        bl_thread_update(main_thread, 1);
         t_threads = tsc_read();
         print_string("done\n");
         t_threads -= t_start;
         printf("execution time: %d\n", t_threads);
+        bl_thread_update(watch_thread,0);
         bl_show_all_signals();
     }
     // Return 0 to satisfy compiler

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,7 +44,7 @@ ALL_TARGETS += $(PRINT_TEST_TARGET)
 
 FOO_TARGET := main.hex
 FOO_SRCS := G431/main.c G431/startup_stm32g431kbtx.s G431/system_stm32g4xx.c G431/platform_g431.c printing.c emblocs.c
-FOO_SRCS += mux2.c sum2.c perftimer.c tmp_gpio.c
+FOO_SRCS += mux2.c sum2.c perftimer.c tmp_gpio.c watch.c
 FOO_SRCS += linked_list.c
 FOO_LIBS :=
 FOO_C_SRC := $(filter %.c, $(FOO_SRCS))

--- a/src/emblocs.h
+++ b/src/emblocs.h
@@ -44,13 +44,8 @@ typedef union bl_sig_data_u {
     bl_u32_t u;
 } bl_sig_data_t;
 
-/* "generic" pin; implemented as a union of the four pin types */
-typedef union bl_pin_u {
-    bl_pin_bit_t b;
-    bl_pin_float_t f;
-    bl_pin_s32_t s;
-    bl_pin_u32_t u;
-} bl_pin_t;
+/* "generic" pin is a pointer to a generic signal */
+typedef bl_sig_data_t *bl_pin_t;
 
 /* realtime data needed for a thread */
 typedef struct bl_thread_data_s {
@@ -86,6 +81,9 @@ typedef enum {
 
 // uncomment this define to halt on errors
 //#define BL_ERROR_HALT
+
+// uncomment this to print lots of detail in 'show' commands
+//#define SHOW_VERBOSE
 
 /**************************************************************
  * Realtime data and object metadata are stored in separate

--- a/src/tmp_gpio.h
+++ b/src/tmp_gpio.h
@@ -17,7 +17,7 @@
  */
 
 #ifndef GPIO_H
-#define GPIO_H PB
+#define GPIO_H
 
 #include <stdint.h>
 #include "platform_g431.h"

--- a/src/watch.c
+++ b/src/watch.c
@@ -74,9 +74,9 @@ bl_inst_meta_t * watch_setup(char const *inst_name, struct bl_comp_def_s const *
     pins = 0;
     types = 0;
     while ( pin_info->name != NULL ) {
-        types |= pin_info->type;
-        types <<= BL_TYPE_BITS;
+        types |= pin_info->type << (pins * BL_TYPE_BITS);
         pins++;
+        pin_info++;
     }
     if ( pins > WATCH_MAX_PINS ) {
         #ifdef BL_ERROR_VERBOSE
@@ -121,32 +121,32 @@ static void bl_watch_update_funct(void *ptr, uint32_t period_ns)
     int pins;
     uint32_t types;
     bl_type_t type;
-    bl_watch_pin_rt_data_t *pin;
+    bl_watch_pin_rt_data_t *watch_pin;
 
     pins = p->pin_count;
     types = p->pin_types;
     // pin data immediately follows the instance structure
-    pin = (bl_watch_pin_rt_data_t *)(p+1);
+    watch_pin = (bl_watch_pin_rt_data_t *)(p+1);
     while ( pins > 0 ) {
         type = types & ((1<<(BL_TYPE_BITS))-1);
         switch(type) {
         case BL_TYPE_BIT:
-            printf(pin->format, *(pin->pin.b));
+            printf(watch_pin->format, watch_pin->pin->b);
             break;
         case BL_TYPE_FLOAT:
-            printf(pin->format, *(pin->pin.f));
+            printf(watch_pin->format, watch_pin->pin->f);
             break;
         case BL_TYPE_S32:
-            printf(pin->format, *(pin->pin.s));
+            printf(watch_pin->format, watch_pin->pin->s);
             break;
         case BL_TYPE_U32:
-            printf(pin->format, *(pin->pin.u));
+            printf(watch_pin->format, watch_pin->pin->u);
             break;
         default:
             break;
         }
         types >>= BL_TYPE_BITS;
-        pin++;
+        watch_pin++;
         pins--;
     }
 }

--- a/src/watch.c
+++ b/src/watch.c
@@ -1,0 +1,153 @@
+// EMBLOCS component - 'watch' for watching signals
+//
+
+#include "emblocs.h"
+#include "watch.h"
+#include "printing.h"
+
+
+#define WATCH_MAX_PINS 14
+#define WATCH_PIN_COUNT_BITS   4
+#define WATCH_PIN_TYPES_BITS  (WATCH_MAX_PINS*BL_TYPE_BITS)
+
+#define WATCH_PIN_COUNT_MASK ((1<<(WATCH_PIN_COUNT_BITS))-1)
+#define WATCH_PIN_TYPES_MASK ((1<<(WATCH_PIN_TYPES_BITS))-1)
+
+
+_Static_assert(((WATCH_PIN_COUNT_BITS+WATCH_PIN_TYPES_BITS) <= 32), "watch bitfields too big");
+
+// instance data structure - one copy per instance in RAM
+// multiple watch_pin_rt_data_t structs are appended to this
+// based on the personality
+typedef struct bl_watch_inst_s {
+    uint32_t pin_count          : WATCH_PIN_COUNT_BITS;
+    uint32_t pin_types          : WATCH_PIN_TYPES_BITS;
+} bl_watch_inst_t;
+
+// pin data structure
+typedef struct bl_watch_pin_s {
+    bl_pin_t pin;
+    char const *format;
+} bl_watch_pin_rt_data_t;
+
+#define WATCH_MAX_INST_SIZE (sizeof(bl_watch_inst_t)+WATCH_MAX_PINS*sizeof(bl_watch_pin_rt_data_t))
+
+_Static_assert((WATCH_MAX_PINS < BL_PIN_COUNT_MAX), "too many pins");
+_Static_assert((WATCH_MAX_INST_SIZE < BL_INST_DATA_MAX_SIZE), "instance structure too large");
+
+
+static void bl_watch_update_funct(void *ptr, uint32_t period_ns);
+
+// array of function definitions - one copy in FLASH
+static bl_funct_def_t const bl_watch_functs[] = {
+    { "update", BL_HAS_FP, &bl_watch_update_funct }
+};
+
+
+/* component-specific setup function */
+bl_inst_meta_t * watch_setup(char const *inst_name, struct bl_comp_def_s const *comp_def, void const *personality);
+
+
+// component definition - one copy in FLASH
+bl_comp_def_t const bl_watch_def = {
+    "watch",
+    watch_setup,
+    sizeof(bl_watch_inst_t),
+    0,
+    _countof(bl_watch_functs),
+    NULL,
+    bl_watch_functs
+};
+
+/* component-specific setup function */
+bl_inst_meta_t * watch_setup(char const *inst_name, struct bl_comp_def_s const *comp_def, void const *personality)
+{
+    watch_pin_config_t *pin_info;
+    bl_watch_pin_rt_data_t *pin_data;
+    uint32_t pins, types;
+    bl_inst_meta_t *meta;
+    bl_watch_inst_t *data;
+    bl_pin_def_t pindef;
+
+    // count pins in personality
+    pin_info = (watch_pin_config_t *)personality;
+    pins = 0;
+    types = 0;
+    while ( pin_info->name != NULL ) {
+        types |= pin_info->type;
+        types <<= BL_TYPE_BITS;
+        pins++;
+    }
+    if ( pins > WATCH_MAX_PINS ) {
+        #ifdef BL_ERROR_VERBOSE
+        print_string("too many pins in personality\n");
+        #endif
+        return NULL;
+    }
+    // now the emblocs setup - create an instance of the proper size to include all the pin data
+    meta = bl_inst_create(inst_name, comp_def, comp_def->data_size + (pins * sizeof(bl_watch_pin_rt_data_t)));
+    data = TO_RT_ADDR(meta->data_index);
+    // fill in instance data fields
+    data->pin_count = pins & WATCH_PIN_COUNT_MASK;
+    data->pin_types = types & WATCH_PIN_TYPES_MASK;
+    // prepare for pin creation
+    pin_info = (watch_pin_config_t *)personality;
+    // dynamic pins follow the main instance data structure
+    pin_data = (bl_watch_pin_rt_data_t *)(data+1);
+    while ( pins > 0 ) {
+        // fill in pin definition
+        pindef.name = pin_info->name;
+        pindef.data_type = pin_info->type;
+        pindef.pin_dir = BL_DIR_IN;
+        pindef.data_offset = TO_INST_SIZE((uint32_t)((char *)&(pin_data->pin) - (char *)data));
+        // create the pin
+        bl_inst_add_pin(meta, &pindef);
+        // save the format string
+        pin_data->format = pin_info->format;
+        // next pin
+        pin_data++;
+        pin_info++;
+        pins--;
+    }
+    return meta;
+}
+
+
+// realtime code - one copy in FLASH
+static void bl_watch_update_funct(void *ptr, uint32_t period_ns)
+{
+    (void)period_ns;  // not used
+    bl_watch_inst_t *p = (bl_watch_inst_t *)ptr;
+    int pins;
+    uint32_t types;
+    bl_type_t type;
+    bl_watch_pin_rt_data_t *pin;
+
+    pins = p->pin_count;
+    types = p->pin_types;
+    // pin data immediately follows the instance structure
+    pin = (bl_watch_pin_rt_data_t *)(p+1);
+    while ( pins > 0 ) {
+        type = types & ((1<<(BL_TYPE_BITS))-1);
+        switch(type) {
+        case BL_TYPE_BIT:
+            printf(pin->format, *(pin->pin.b));
+            break;
+        case BL_TYPE_FLOAT:
+            printf(pin->format, *(pin->pin.f));
+            break;
+        case BL_TYPE_S32:
+            printf(pin->format, *(pin->pin.s));
+            break;
+        case BL_TYPE_U32:
+            printf(pin->format, *(pin->pin.u));
+            break;
+        default:
+            break;
+        }
+        types >>= BL_TYPE_BITS;
+        pin++;
+        pins--;
+    }
+}
+

--- a/src/watch.h
+++ b/src/watch.h
@@ -1,0 +1,31 @@
+/*********************************************
+ *
+ * Signal watching component:
+ *
+ * This component exports pins which can be connected to
+ * signals that you want to observe.  When its update()
+ * function runs, the value of each pin is output to the
+ * console, using a printf format string that is part of
+ * the personality.
+ *
+ * The personality is an array of watch_pin_config_t
+ * structures.  The end of the array is marked by an
+ * entry with NULL in the 'name' and 'format' fields.
+ *
+ * A single instance of 'watch' is limited to 14 pins,
+ * but you can have as many instances as you want.
+ *
+ */
+
+#ifndef WATCH_H
+#define WATCH_H
+
+#include "emblocs.h"
+
+typedef struct watch_pin_config_s {
+    bl_type_t type;
+    char const *name;
+    char const *format;
+} watch_pin_config_t;
+
+#endif // WATCH_H


### PR DESCRIPTION
the 'watch' component exports emblocs pins based on a personality.  Its update function reads the values of those pins and calls printf with a format string (also from the personality) and the pin value.  Can be used to display the value of signals at runtime by linking the pins to the desired signals.