### PR TITLE
Function metadata

### DIFF
--- a/src/emblocs_api.h
+++ b/src/emblocs_api.h
@@ -126,6 +126,8 @@ void bl_show_all_instances(void);
 void bl_show_all_signals(void);
 void bl_show_all_threads(void);
 void bl_show_instance(struct bl_instance_meta_s const *inst);
+void bl_show_pin(struct bl_pin_meta_s const *pin);
+void bl_show_funct(struct bl_function_meta_s const *funct);
 void bl_show_signal(struct bl_signal_meta_s const *sig);
 void bl_show_thread(struct bl_thread_meta_s const *thread);
 

--- a/src/emblocs_api.h
+++ b/src/emblocs_api.h
@@ -54,7 +54,7 @@ struct bl_instance_meta_s *bl_instance_find(char const *name);
 struct bl_signal_meta_s *bl_signal_find(char const *name);
 struct bl_thread_meta_s *bl_thread_find(char const *name);
 struct bl_pin_meta_s *bl_pin_find_in_instance(char const *name, struct bl_instance_meta_s *inst);
-struct bl_function_def_s *bl_function_find_in_instance(char const *name, struct bl_instance_meta_s *inst);
+struct bl_function_meta_s *bl_function_find_in_instance(char const *name, struct bl_instance_meta_s *inst);
 
 /**************************************************************
  * Link the specified pin to the specified signal
@@ -79,7 +79,7 @@ bl_retval_t bl_pin_set(struct bl_pin_meta_s const *pin, bl_sig_data_t const *val
 /**************************************************************
  * Add the specified function to the end of the specified thread
  */
-bl_retval_t bl_thread_add_function(struct bl_thread_meta_s const *thread, struct bl_instance_meta_s const *inst, struct bl_function_def_s const *funct);
+bl_retval_t bl_function_linkto_thread(struct bl_function_meta_s const *funct, struct bl_thread_meta_s const *thread);
 
 /**************************************************************
  * A structure that carries the realtime data for a thread.

--- a/src/emblocs_api.h
+++ b/src/emblocs_api.h
@@ -61,10 +61,12 @@ struct bl_function_meta_s *bl_function_find_in_instance(char const *name, struct
  */
 bl_retval_t bl_pin_linkto_signal(struct bl_pin_meta_s const *pin, struct bl_signal_meta_s const *sig);
 
+#ifdef BL_ENABLE_UNLINK
 /**************************************************************
  * Disconnect the specified pin from any signal
  */
 bl_retval_t bl_pin_unlink(struct bl_pin_meta_s const *pin);
+#endif
 
 /**************************************************************
  * Set the specified signal to a value
@@ -79,7 +81,14 @@ bl_retval_t bl_pin_set(struct bl_pin_meta_s const *pin, bl_sig_data_t const *val
 /**************************************************************
  * Add the specified function to the end of the specified thread
  */
-bl_retval_t bl_function_linkto_thread(struct bl_function_meta_s const *funct, struct bl_thread_meta_s const *thread);
+bl_retval_t bl_function_linkto_thread(struct bl_function_meta_s *funct, struct bl_thread_meta_s const *thread);
+
+#ifdef BL_ENABLE_UNLINK
+/**************************************************************
+ * Disconnect the specified function from any thread
+ */
+bl_retval_t bl_function_unlink(struct bl_function_meta_s *funct);
+#endif
 
 /**************************************************************
  * A structure that carries the realtime data for a thread.

--- a/src/emblocs_comp.h
+++ b/src/emblocs_comp.h
@@ -154,8 +154,10 @@ struct bl_instance_meta_s *bl_instance_create(char const *name, bl_comp_def_t co
 void *bl_instance_data_addr(struct bl_instance_meta_s *inst);
 
 /**************************************************************
- * helper function for new instance:
- * adds a pin as defined by 'def' to instance 'inst'
+ * Helper functions for new instance:
+ */
+
+/* Adds a pin as defined by 'def' to instance 'inst'
  * allocates a new bl_pin_meta_t struct in meta RAM 
  * allocates a dummy signal in RT ram
  * fills in all fields in the meta struct
@@ -163,5 +165,29 @@ void *bl_instance_data_addr(struct bl_instance_meta_s *inst);
  * adds the meta struct to 'inst' pin list
  */
 bl_retval_t bl_instance_add_pin(struct bl_instance_meta_s *inst, bl_pin_def_t const *def);
+
+/* Adds all pins defined by 'def' to instance 'inst'.
+ * This function calls bl_instance_add_pin() for each pin
+ * definition in 'def'.  It is called by bl_default_setup()
+ * and can be called from component-specific setup functions.
+ */
+bl_retval_t bl_instance_add_pins(struct bl_instance_meta_s *inst, bl_comp_def_t const *def);
+
+/* Adds a function as defined by 'def' to instance 'inst'
+ * allocates a new bl_function_meta_t struct in meta RAM
+ * allocates a bl_function_rtdata_t struct in RT ram
+ * fills in all fields in both structures
+ * links the meta struct to the rtdata struct
+ * adds the meta struct to 'inst' function list
+ */
+bl_retval_t bl_instance_add_function(struct bl_instance_meta_s *inst, bl_function_def_t const *def);
+
+/* Adds all functions defined by 'def' to instance 'inst'.
+ * This function calls bl_instance_add_function() for each
+ * function definition in 'def'.  It is called by
+ * bl_default_setup() and can be called from component-
+ * specific setup functions.
+ */
+bl_retval_t bl_instance_add_functions(struct bl_instance_meta_s *inst, bl_comp_def_t const *def);
 
 #endif // EMBLOCS_COMP_H

--- a/src/emblocs_config.h
+++ b/src/emblocs_config.h
@@ -21,6 +21,21 @@
  * details such as memory addresses, indexes, etc. */
 //#define BL_SHOW_VERBOSE
 
+/* uncomment this define to enable pin and function
+ * 'unlink' commands */
+#define BL_ENABLE_UNLINK
+
+/* uncomment this define to enable pin and function
+ * 'linkto' commands to unlink previously linked
+ * objects; this also defines BL_ENABLE_UNLINK */
+#define BL_ENABLE_IMPLICIT_UNLINK
+
+#ifdef BL_ENABLE_IMPLICIT_UNLINK
+#ifndef BL_ENABLE_UNLINK
+#define BL_ENABLE_UNLINK
+#endif
+#endif
+
 /* size of the memory pool for realtime data */
 #define BL_RT_POOL_SIZE     (2048)
 

--- a/src/emblocs_core.h
+++ b/src/emblocs_core.h
@@ -104,7 +104,7 @@ typedef enum {
  */
 struct bl_instance_meta_s;
 struct bl_pin_meta_s;
-struct bl_function_def_s;
+struct bl_function_meta_s;
 struct bl_signal_meta_s;
 struct bl_thread_meta_s;
 struct bl_thread_data_s;

--- a/src/emblocs_init.c
+++ b/src/emblocs_init.c
@@ -260,7 +260,7 @@ bl_retval_t bl_init_threads(char const * const threads[])
     uint32_t period_ns;
     bl_thread_meta_t *thread;
     bl_instance_meta_t *inst;
-    bl_function_def_t const *function_def;
+    bl_function_meta_t *function;
     int errors = 0;
 
     enum {
@@ -329,15 +329,15 @@ bl_retval_t bl_init_threads(char const * const threads[])
             }
             break;
         case GET_FUNCT:
-            function_def = bl_function_find_in_instance(*threads, inst);
+            function = bl_function_find_in_instance(*threads, inst);
             #ifndef BL_ERROR_HALT
-            if ( function_def == NULL ) {
+            if ( function == NULL ) {
                 errors++;
                 state = GOT_NAME;
                 break;
             }
             #endif
-            retval = bl_thread_add_function(thread, inst, function_def);
+            retval = bl_function_linkto_thread(function, thread);
             #ifndef BL_ERROR_HALT
             if ( retval != BL_SUCCESS ) {
                 errors++;

--- a/src/emblocs_priv.h
+++ b/src/emblocs_priv.h
@@ -116,26 +116,29 @@ _Static_assert((BL_RT_INDEX_BITS*2+BL_TYPE_BITS+BL_DIR_BITS) <= 32, "pin bitfiel
  * Data structure that describes a function.  Each instance
  * has a list of functions.  These structures live in the
  * metadata pool, but point to data in the realtime pool.
+ * (note: thread_index is set to BL_META_MAX_INDEX if the
+ *  function is NOT in a thread; can't use zero for that
+ *  since if a thread was the first object created its
+ *  index would be zero)
  */
 
  typedef struct bl_function_meta_s {
     struct bl_function_meta_s *next;
     uint32_t rtdata_index  : BL_RT_INDEX_BITS;
     uint32_t nofp          : BL_NOFP_BITS;
+    uint32_t thread_index  : BL_META_INDEX_BITS;
     char const *name;
 } bl_function_meta_t;
 
 /* Verify that bitfields fit in one uint32_t */
-_Static_assert((BL_RT_INDEX_BITS+BL_NOFP_BITS) <= 32, "function bitfields too big");
+_Static_assert((BL_RT_INDEX_BITS+BL_NOFP_BITS+BL_META_INDEX_BITS) <= 32, "function bitfields too big");
 
 /**************************************************************
  * Realtime data for a function.  These structures are created
  * when the instance is created.  Later, when the function is
- * added to a realtime thread, this structure is linked into
- * the list that corresponds to the thread.
- * The 'next' pointer is used to link functions into a thread.
- * If it points to itself, the function is not currently part
- * of a thread.
+ * added to a realtime thread, the 'next' field is used to
+ * link this structure into the list that corresponds to the
+ * thread.
  */
 typedef struct bl_function_rtdata_s {
     bl_rt_function_t *funct;

--- a/src/emblocs_show.c
+++ b/src/emblocs_show.c
@@ -7,8 +7,6 @@
 /**************************************************************
  * Helper functions for finding things in the metadata
  *
- * These functions are implemented in emblocs_priv.c
- *
  * The first group finds the single matching item.
  * The second group finds the zero or more matching items,
  * calls a callback functions for each match (if 'callback'
@@ -25,12 +23,13 @@ static int bl_find_pins_linked_to_signal(bl_signal_meta_t const *sig, void (*cal
 
 static void bl_show_pin(bl_pin_meta_t const *pin);
 static void bl_show_all_pins_of_instance(bl_instance_meta_t const *inst);
+static void bl_show_all_functions_of_instance(bl_instance_meta_t const *inst);
 static void bl_show_pin_value(bl_pin_meta_t const *pin);
 static void bl_show_pin_linkage(bl_pin_meta_t const *pin);
 static void bl_show_signal_value(bl_signal_meta_t const *sig);
 static void bl_show_signal_linkage(bl_signal_meta_t const *sig);
 static void bl_show_sig_data_t_value(bl_sig_data_t const *data, bl_type_t type);
-static void bl_show_thread_entry(bl_thread_entry_t const *entry);
+static void bl_show_function_rtdata(bl_function_rtdata_t const *funct);
 
 
 static char const * const types[] = {
@@ -66,6 +65,7 @@ void bl_show_instance(struct bl_instance_meta_s const *inst)
     printf("instance '%s' of component '%s'\n", inst->name, inst->comp_def->name);
 #endif
     bl_show_all_pins_of_instance(inst);
+    bl_show_all_functions_of_instance(inst);
 }
 
 static void instance_meta_print_node(void *node)
@@ -148,6 +148,37 @@ static void bl_show_pin_linkage(bl_pin_meta_t const *pin)
     }
 }
 
+static void bl_show_function(bl_function_meta_t const *funct)
+{
+    bl_function_rtdata_t *rtdata_addr;
+
+    rtdata_addr = (bl_function_rtdata_t *)TO_RT_ADDR(funct->rtdata_index);
+#ifdef BL_SHOW_VERBOSE
+    printf(" FUNCT: %20s  %s @ %p, rtdata @ [%3d]=%p\n",
+                            funct->name, nofp[funct->nofp], funct,
+                            funct->rtdata_index, rtdata_addr);
+#else
+    printf("  %-12s ", funct->name);
+    if ( rtdata_addr->next == rtdata_addr ) {
+        printf(" not in a thread");
+    }
+    printf("\n");
+#endif
+}
+
+static void function_meta_print_node(void *node)
+{
+    bl_show_function((bl_function_meta_t *)node);
+}
+
+static void bl_show_all_functions_of_instance(bl_instance_meta_t const *inst)
+{
+    int ll_result;
+
+    ll_result = ll_traverse((void **)(&inst->function_list), function_meta_print_node);
+    printf("    %d functions\n", ll_result);
+}
+
 void bl_show_signal(struct bl_signal_meta_s const *sig)
 {
 #ifdef BL_SHOW_VERBOSE
@@ -226,16 +257,16 @@ void bl_show_all_signals(void)
     printf("Total of %d signals\n", ll_result);
 }
 
-static void bl_show_thread_entry(bl_thread_entry_t const *entry)
+static void bl_show_function_rtdata(bl_function_rtdata_t const *rtdata)
 {
 #ifdef BL_SHOW_VERBOSE
-    printf("  thread_entry @[%d]=%p, calls %p, inst data @%p\n", TO_RT_INDEX(entry), entry, entry->funct, entry->instance_data);
+    printf("  function_rtdata @[%d]=%p, calls %p, inst data @%p\n", TO_RT_INDEX(rtdata), rtdata, rtdata->funct, rtdata->instance_data);
 #else
     bl_instance_meta_t *inst;
     bl_function_def_t *funct;
 
-    inst = bl_find_instance_by_data_addr(entry->instance_data);
-    funct = bl_find_function_def_in_instance_by_address(entry->funct, inst);
+    inst = bl_find_instance_by_data_addr(rtdata->instance_data);
+    funct = bl_find_function_def_in_instance_by_address(rtdata->funct, inst);
     printf("     %s.%s\n", inst->name, funct->name);
 #endif
 }
@@ -244,33 +275,33 @@ void bl_show_thread(struct bl_thread_meta_s const *thread)
 {
 #ifdef BL_SHOW_VERBOSE
     bl_thread_data_t *data;
-    bl_thread_entry_t *entry;
+    bl_function_rtdata_t *funct_data;
 
     data = TO_RT_ADDR(thread->data_index);
-    entry = data->start;
+    funct_data = data->start;
     printf(" thread '%s' @[%d]=%p, no_fp = %d, period_ns = %d, RT data at [%d]=%p\n", thread->name, 
                                 TO_RT_INDEX(thread), thread, thread->nofp, data->period_ns,
                                 thread->data_index, data);
-    while ( entry != NULL ) {
-        bl_show_thread_entry(entry);
-        entry = entry->next;
+    while ( funct_data != NULL ) {
+        bl_show_function_rtdata(funct_data);
+        funct_data = funct_data->next;
     }
 #else
     bl_thread_data_t *data;
-    bl_thread_entry_t *entry;
+    bl_function_rtdata_t *funct_data;
     char *fp_str;
 
     data = TO_RT_ADDR(thread->data_index);
-    entry = data->start;
+    funct_data = data->start;
     if ( thread->nofp ) {
         fp_str = "no fp ";
     } else {
         fp_str = "has fp";
     }
     printf("  %-12s = %s : %10d nsec\n", thread->name, fp_str, data->period_ns);
-    while ( entry != NULL ) {
-        bl_show_thread_entry(entry);
-        entry = entry->next;
+    while ( funct_data != NULL ) {
+        bl_show_function_rtdata(funct_data);
+        funct_data = funct_data->next;
     }
 #endif
 }

--- a/src/emblocs_show.c
+++ b/src/emblocs_show.c
@@ -21,7 +21,6 @@ static bl_function_def_t *bl_find_function_def_in_instance_by_address(bl_rt_func
 static int bl_find_pins_linked_to_signal(bl_signal_meta_t const *sig, void (*callback)(bl_instance_meta_t *inst, bl_pin_meta_t *pin));
 //static int bl_find_functions_in_thread(bl_thread_meta_t const *thread, void (*callback)(bl_instance_meta_t *inst, bl_function_def_t *funct));
 
-static void bl_show_pin(bl_pin_meta_t const *pin);
 static void bl_show_all_pins_of_instance(bl_instance_meta_t const *inst);
 static void bl_show_all_functions_of_instance(bl_instance_meta_t const *inst);
 static void bl_show_pin_value(bl_pin_meta_t const *pin);
@@ -82,7 +81,7 @@ void bl_show_all_instances(void)
     printf("Total of %d instances\n", ll_result);
 }
 
-static void bl_show_pin(bl_pin_meta_t const *pin)
+void bl_show_pin(bl_pin_meta_t const *pin)
 {
 #ifdef BL_SHOW_VERBOSE
     bl_sig_data_t *dummy_addr, **ptr_addr, *ptr_val;
@@ -148,19 +147,22 @@ static void bl_show_pin_linkage(bl_pin_meta_t const *pin)
     }
 }
 
-static void bl_show_function(bl_function_meta_t const *funct)
+void bl_show_function(bl_function_meta_t const *funct)
 {
-    bl_function_rtdata_t *rtdata_addr;
+    bl_thread_meta_t *thread;
 
-    rtdata_addr = (bl_function_rtdata_t *)TO_RT_ADDR(funct->rtdata_index);
 #ifdef BL_SHOW_VERBOSE
+    bl_function_rtdata_t *rtdata_addr = (bl_function_rtdata_t *)TO_RT_ADDR(funct->rtdata_index);
     printf(" FUNCT: %20s  %s @ %p, rtdata @ [%3d]=%p\n",
                             funct->name, nofp[funct->nofp], funct,
                             funct->rtdata_index, rtdata_addr);
 #else
     printf("  %-12s ", funct->name);
-    if ( rtdata_addr->next == rtdata_addr ) {
-        printf(" not in a thread");
+    if ( funct->thread_index == BL_META_MAX_INDEX ) {
+        printf(" (no thread)");
+    } else {
+        thread = TO_META_ADDR(funct->thread_index);
+        printf(" %s", thread->name);
     }
     printf("\n");
 #endif

--- a/src/tmp_gpio.c
+++ b/src/tmp_gpio.c
@@ -203,6 +203,8 @@ struct bl_instance_meta_s *gpio_setup(char const *instance_name, struct bl_comp_
         }
         active_bit <<= 1;
     }
+    // finally, create the functions; nothing custom here
+    bl_instance_add_functions(meta, comp_def);
     return meta;
 }
 

--- a/src/watch.c
+++ b/src/watch.c
@@ -109,6 +109,8 @@ struct bl_instance_meta_s *watch_setup(char const *instance_name, struct bl_comp
         pin_info++;
         pins--;
     }
+    // finally, create the functions; nothing custom here
+    bl_instance_add_functions(meta, comp_def);
     return meta;
 }
 


### PR DESCRIPTION
Make the API more symmetrical:

Pins belong to components and can be linked to or unlinked from signals
Functions belong to components and can be linked to or unlinked from threads

Made the unlink commands optional with a compile-time config
Modified the linkto commands such that they won't re-link an already linked object (compile time config)
